### PR TITLE
chore(build) bump bumper-plugin to 4.3.4

### DIFF
--- a/kong-images/build.yml
+++ b/kong-images/build.yml
@@ -9,7 +9,7 @@ enterprise:
     key_name: bumper-plugin
     repo_name: bumper-plugin
     github_url: git@github.com:jeremymv2/bumper.git
-    version: 3.3.0
+    version: 4.3.4
   - name: some-other-plugin
     key_name: other-plugin
     repo_name: other-plugin


### PR DESCRIPTION
Bumping plugin pin with new tag version.         https://github.com/Kong/bumper-plugin/tree/4.3.4