### PR TITLE
chore(build) bump bumper to 3.5.9

### DIFF
--- a/kong-images/build.yml
+++ b/kong-images/build.yml
@@ -9,7 +9,7 @@ enterprise:
     key_name: bumper-plugin
     repo_name: bumper
     github_url: git@github.com:jeremymv2/bumper.git
-    version: 3.4.2
+    version: 3.5.9
   - name: some-other-plugin
     key_name: other-plugin
     repo_name: other-plugin


### PR DESCRIPTION
Bumping plugin pin with new tag version.         https://github.com/Kong/bumper/tree/3.5.9