### PR TITLE
chore(build) bump bumper3 to 0.38.5

### DIFF
--- a/kong-images/build.yml
+++ b/kong-images/build.yml
@@ -24,4 +24,4 @@ enterprise:
     key_name: bumper3-plugin
     repo_name: bumper3
     github_url: git@github.com:jeremymv2/bumper3.git
-    version: 0.38.1
+    version: 0.38.5


### PR DESCRIPTION
Bumping plugin pin with new tag version.         https://github.com/Kong/bumper3/tree/0.38.5