### PR TITLE
chore(build) bump bumper2 to 0.10.0

### DIFF
--- a/kong-images/build.yml
+++ b/kong-images/build.yml
@@ -14,7 +14,7 @@ enterprise:
     key_name: bumper2-plugin
     repo_name: bumper2
     github_url: git@github.com:jeremymv2/bumper2.git
-    version: 0.2.0
+    version: 0.10.0
   - name: some-other-plugin
     key_name: other-plugin
     repo_name: other-plugin


### PR DESCRIPTION
Bumping plugin pin with new tag version.         https://github.com/Kong/bumper2/tree/0.10.0