### PR TITLE
chore(build) bump bumper to 12.0.0

### DIFF
--- a/kong-images/build.yml
+++ b/kong-images/build.yml
@@ -9,7 +9,7 @@ enterprise:
     key_name: bumper-plugin
     repo_name: bumper
     github_url: git@github.com:jeremymv2/bumper.git
-    version: 4.0.0
+    version: 12.0.0
   - name: bumper2-plugin
     key_name: bumper2-plugin
     repo_name: bumper2


### PR DESCRIPTION
Bumping plugin pin with new tag version.         https://github.com/Kong/bumper/tree/12.0.0